### PR TITLE
Fix typo: vercel -> Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This app is not currently configurable. The values are hardcoded:
 
 ### Vercel
 
-This app is running on [vercel](https://vercel.com/) using [Serverless Functions](https://vercel.com/docs/serverless-functions/introduction).
+This app is running on [Vercel](https://vercel.com/) using [Serverless Functions](https://vercel.com/docs/serverless-functions/introduction).
 
 #### Environment Variables
 


### PR DESCRIPTION
## Description
* **V**ercel
    <img width="296" alt="스크린샷 2021-08-23 오후 6 10 25" src="https://user-images.githubusercontent.com/32605822/130421607-9cb15d06-4372-4bf2-beeb-3c7b832fe4ed.png">
* **G**itHub
* **Y**ouTube
* **T**ypeScript
* **J**avaScript

## Review Notes
- https://github.com/junhoyeo/github-rank-in-dimigo/pull/4
> From that day, I never used the word `GitHub` wrong again